### PR TITLE
v2.1.0

### DIFF
--- a/examples/full/main.tf
+++ b/examples/full/main.tf
@@ -20,7 +20,7 @@ locals {
 
 module "jenkins_ha_agents" {
   source  = "neiman-marcus/jenkins-ha-agents/aws"
-  version = "2.0.1"
+  version = "2.1.0"
 
   admin_password = var.admin_password
   agent_max      = var.agent_max
@@ -47,13 +47,9 @@ module "jenkins_ha_agents" {
   jenkins_version        = var.jenkins_version
   password_ssm_parameter = var.password_ssm_parameter
 
-  private_cidr_ingress    = var.private_cidr_ingress
-  private_subnet_name_az1 = var.private_subnet_name_az1
-  private_subnet_name_az2 = var.private_subnet_name_az2
-
-  public_cidr_ingress    = var.public_cidr_ingress
-  public_subnet_name_az1 = var.public_subnet_name_az1
-  public_subnet_name_az2 = var.public_subnet_name_az2
+  cidr_ingress        = var.cidr_ingress
+  private_subnet_name = var.private_subnet_name
+  public_subnet_name  = var.public_subnet_name
 
   r53_record      = var.r53_record
   region          = var.region

--- a/examples/full/terraform.tfvars
+++ b/examples/full/terraform.tfvars
@@ -14,27 +14,25 @@ auto_update_plugins_cron = "0 0 31 2 *"
 
 bastion_sg_name = "bastion-sg"
 
+cidr_ingress = ["0.0.0.0/0"]
+
+contact = "admin@foo.io"
+
 domain_name = "foo.io."
 
-executors = "4"
+environment = "prod"
+
+executors = 4
 
 instance_type = "t2.large"
 
-jenkins_version = "2.176.2"
+jenkins_version = "2.176.3"
 
 password_ssm_parameter = "/admin_password"
 
-private_cidr_ingress = ["10.0.0.0/8"]
+private_subnet_name = "private-subnet-*"
 
-private_subnet_name_az1 = "private-subnet-a"
-
-private_subnet_name_az2 = "private-subnet-b"
-
-public_cidr_ingress = ["0.0.0.0/0"]
-
-public_subnet_name_az1 = "public-subnet-a"
-
-public_subnet_name_az2 = "public-subnet-b"
+public_subnet_name = "public-subnet-*"
 
 r53_record = "jenkins.foo.io"
 

--- a/examples/full/variables.tf
+++ b/examples/full/variables.tf
@@ -41,8 +41,15 @@ variable "bastion_sg_name" {
   description = "The bastion security group name to allow to ssh to the master/agents."
 }
 
+variable "cidr_ingress" {
+  description = "IP address cidr ranges allowed access to the LB."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
 variable "contact" {
   description = "The email of the contact who owns or manages this infrastructure."
+  default     = "admin@foo.io"
 }
 
 variable "domain_name" {
@@ -66,7 +73,7 @@ variable "instance_type" {
 
 variable "jenkins_version" {
   description = "The version number of Jenkins to use on the master. Change this value when a new version comes out, and it will update the launch configuration and the autoscaling group."
-  default     = "2.176.2"
+  default     = "2.176.3"
 }
 
 variable "password_ssm_parameter" {
@@ -74,32 +81,12 @@ variable "password_ssm_parameter" {
   default     = "/admin_password"
 }
 
-variable "private_cidr_ingress" {
-  description = "Private IP address cidr ranges allowed access to the instances."
-  type        = list(string)
-  default     = ["10.0.0.0/8"]
+variable "private_subnet_name" {
+  description = "The name prefix of the private subnets to pull in as a data source."
 }
 
-variable "private_subnet_name_az1" {
-  description = "The name prefix of the private subnet in the first AZ to pull in as a data source."
-}
-
-variable "private_subnet_name_az2" {
-  description = "The name prefix of the private subnet in the second AZ to pull in as a data source."
-}
-
-variable "public_cidr_ingress" {
-  description = "Public IP address cidr ranges allowed access to the instances."
-  type        = list(string)
-  default     = ["0.0.0.0/0"]
-}
-
-variable "public_subnet_name_az1" {
-  description = "The name prefix of the public subnet in the first AZ to pull in as a data source."
-}
-
-variable "public_subnet_name_az2" {
-  description = "The name prefix of the public subnet in the second AZ to pull in as a data source."
+variable "public_subnet_name" {
+  description = "The name prefix of the public subnets to pull in as a data source."
 }
 
 variable "r53_record" {

--- a/examples/minimum/main.tf
+++ b/examples/minimum/main.tf
@@ -20,16 +20,14 @@ locals {
 
 module "jenkins_ha_agents" {
   source  = "neiman-marcus/jenkins-ha-agents/aws"
-  version = "2.0.1"
+  version = "2.1.0"
 
   admin_password  = var.admin_password
   bastion_sg_name = var.bastion_sg_name
   domain_name     = var.domain_name
 
-  private_subnet_name_az1 = var.private_subnet_name_az1
-  private_subnet_name_az2 = var.private_subnet_name_az2
-  public_subnet_name_az1  = var.public_subnet_name_az1
-  public_subnet_name_az2  = var.public_subnet_name_az2
+  private_subnet_name = var.private_subnet_name
+  public_subnet_name  = var.public_subnet_name
 
   r53_record = var.r53_record
   region     = var.region

--- a/examples/minimum/terraform.tfvars
+++ b/examples/minimum/terraform.tfvars
@@ -6,13 +6,9 @@ domain_name = "foo.io."
 
 environment = "prod"
 
-private_subnet_name_az1 = "private-subnet-a"
+private_subnet_name = "private-subnet-*"
 
-private_subnet_name_az2 = "private-subnet-b"
-
-public_subnet_name_az1 = "public-subnet-a"
-
-public_subnet_name_az2 = "public-subnet-b"
+public_subnet_name = "public-subnet-*"
 
 r53_record = "jenkins.foo.io"
 

--- a/examples/minimum/variables.tf
+++ b/examples/minimum/variables.tf
@@ -8,6 +8,7 @@ variable "bastion_sg_name" {
 
 variable "contact" {
   description = "The email of the contact who owns or manages this infrastructure."
+  default     = "admin@foo.io"
 }
 
 variable "domain_name" {
@@ -16,22 +17,15 @@ variable "domain_name" {
 
 variable "environment" {
   description = "The environment type, prod or nonprod."
+  default     = "prod"
 }
 
-variable "private_subnet_name_az1" {
-  description = "The name prefix of the private subnet in the first AZ to pull in as a data source."
+variable "private_subnet_name" {
+  description = "The name prefix of the private subnets to pull in as a data source."
 }
 
-variable "private_subnet_name_az2" {
-  description = "The name prefix of the private subnet in the second AZ to pull in as a data source."
-}
-
-variable "public_subnet_name_az1" {
-  description = "The name prefix of the public subnet in the first AZ to pull in as a data source."
-}
-
-variable "public_subnet_name_az2" {
-  description = "The name prefix of the public subnet in the second AZ to pull in as a data source."
+variable "public_subnet_name" {
+  description = "The name prefix of the public subnets to pull in as a data source."
 }
 
 variable "r53_record" {

--- a/init/master-write-files.cfg
+++ b/init/master-write-files.cfg
@@ -217,10 +217,10 @@ write_files:
       if [ ! -f "/var/lib/jenkins/api_key.txt" ]; then
           CRUMB=$(curl -s http://localhost:8080/crumbIssuer/api/json --user admin:${admin_password} | jq -r .crumb)
           API_KEY=$(curl -s -X POST http://localhost:8080/me/descriptorByName/jenkins.security.ApiTokenProperty/generateNewToken --user admin:${admin_password} --data newTokenName=agent-token -H "Jenkins-Crumb: $CRUMB" | jq -r .data.tokenValue)
+          
           echo $API_KEY > /var/lib/jenkins/api_key.txt
+          aws ssm put-parameter --name "${api_ssm_parameter}" --value "$(cat /var/lib/jenkins/api_key.txt)" --type "SecureString" --overwrite --region ${aws_region}
       fi
-
-      aws ssm put-parameter --name "${api_ssm_parameter}" --value "$(cat /var/lib/jenkins/api_key.txt)" --type "SecureString" --overwrite --region ${aws_region}
 
       sed -i -e "s@APIKEY@$(cat /var/lib/jenkins/api_key.txt)@" /opt/cloudwatch-busy-executors.sh
       sed -i -e "s@APIKEY@$(cat /var/lib/jenkins/api_key.txt)@" /opt/cloudwatch-idle-executors.sh

--- a/variables.tf
+++ b/variables.tf
@@ -41,6 +41,12 @@ variable "bastion_sg_name" {
   description = "The bastion security group name to allow to ssh to the master/agents."
 }
 
+variable "cidr_ingress" {
+  description = "IP address cidr ranges allowed access to the LB."
+  type        = list(string)
+  default     = ["0.0.0.0/0"]
+}
+
 variable "custom_plugins" {
   default     = ""
   description = "Custom plugins to install alongside the defaults. Pull from outside the module."
@@ -82,7 +88,7 @@ variable "instance_type" {
 
 variable "jenkins_version" {
   description = "The version number of Jenkins to use on the master. Change this value when a new version comes out, and it will update the launch configuration and the autoscaling group."
-  default     = "2.176.2"
+  default     = "2.176.3"
 }
 
 variable "password_ssm_parameter" {
@@ -90,32 +96,12 @@ variable "password_ssm_parameter" {
   default     = "/admin_password"
 }
 
-variable "private_cidr_ingress" {
-  description = "Private IP address cidr ranges allowed access to the instances."
-  type        = list(string)
-  default     = ["10.0.0.0/8"]
+variable "private_subnet_name" {
+  description = "The name prefix of the private subnets to pull in as a data source."
 }
 
-variable "private_subnet_name_az1" {
-  description = "The name prefix of the private subnet in the first AZ to pull in as a data source."
-}
-
-variable "private_subnet_name_az2" {
-  description = "The name prefix of the private subnet in the second AZ to pull in as a data source."
-}
-
-variable "public_cidr_ingress" {
-  description = "Public IP address cidr ranges allowed access to the instances."
-  type        = list(string)
-  default     = ["0.0.0.0/0"]
-}
-
-variable "public_subnet_name_az1" {
-  description = "The name prefix of the public subnet in the first AZ to pull in as a data source."
-}
-
-variable "public_subnet_name_az2" {
-  description = "The name prefix of the public subnet in the second AZ to pull in as a data source."
+variable "public_subnet_name" {
+  description = "The name prefix of the public subnets to pull in as a data source."
 }
 
 variable "r53_record" {


### PR DESCRIPTION
* Update subnets to use wildcard, so they are dynamically created in more than two AZ's.
* Refactor to accommodate new subnets selection.
* New Jenkins LTS version.
* Updated examples, and README.md.
* Tested in nonprod

Please note the following breaking changes, which is reflected in the README.md:

### v2.1.0

 * This version of the module pulls all public and private subnets using a wildcard.
   * This allows for more than two hardcoded subnets.
   * You may have to destroy several resources and create them again, including mount targets.
   * As long as you do not delete your EFS volume, there should be no data loss.
 * Cidr blocks have been consolidated to reduce redundant configuration.
