### PR TITLE
fix curl password quoting and crumb validation issue

### DIFF
--- a/init/master-write-files.cfg
+++ b/init/master-write-files.cfg
@@ -215,8 +215,8 @@ write_files:
       #!/bin/bash
 
       if [ ! -f "/var/lib/jenkins/api_key.txt" ]; then
-          CRUMB=$(curl -s http://localhost:8080/crumbIssuer/api/json --user admin:${admin_password} | jq -r .crumb)
-          API_KEY=$(curl -s -X POST http://localhost:8080/me/descriptorByName/jenkins.security.ApiTokenProperty/generateNewToken --user admin:${admin_password} --data newTokenName=agent-token -H "Jenkins-Crumb: $CRUMB" | jq -r .data.tokenValue)
+          CRUMB=$(curl -c cookies.txt -s http://localhost:8080/crumbIssuer/api/json --user 'admin:${admin_password}' | jq -r .crumb)
+          API_KEY=$(curl -b cookies.txt -s -X POST http://localhost:8080/me/descriptorByName/jenkins.security.ApiTokenProperty/generateNewToken --user 'admin:${admin_password}' --data newTokenName=agent-token -H "Jenkins-Crumb: $CRUMB" | jq -r .data.tokenValue)
           
           echo $API_KEY > /var/lib/jenkins/api_key.txt
           aws ssm put-parameter --name "${api_ssm_parameter}" --value "$(cat /var/lib/jenkins/api_key.txt)" --type "SecureString" --overwrite --region ${aws_region}


### PR DESCRIPTION
Post Jenkins 2.192 and Jenkins LTS 2.176.3, getting the agent token will fail due to updated crumb validation which requires the session to match. See https://jenkins.io/security/advisory/2019-08-28/ for more info.

The result is that agent instances shutdown shortly after startup with the instance system log showing:
```
failed to fetch slave info from jenkins code 401
```
The ASG will then try to launch another which will fail...