### PR TITLE
Fix awscli.conf

### DIFF
--- a/init/agent-runcmd.cfg
+++ b/init/agent-runcmd.cfg
@@ -5,6 +5,7 @@ runcmd:
   - yum clean metadata
   - yum install -y docker git java-1.8.0-amazon-corretto-devel python3-pip jq nfs-utils awslogs tree
   - mv /bin/pip /bin/pip2 && cp /bin/pip3 /bin/pip
+  - cp /etc/awslogs/awscli.conf.desired /etc/awslogs/awscli.conf
   - systemctl enable awslogsd
   - systemctl start awslogsd
   - service docker start

--- a/init/agent-write-files.cfg
+++ b/init/agent-write-files.cfg
@@ -1,7 +1,7 @@
 #cloud-config
 
 write_files:
-  - path: /etc/awslogs/awscli.conf
+  - path: /etc/awslogs/awscli.conf.desired
     content: |
       [default]
       region = ${aws_region}

--- a/init/master-runcmd.cfg
+++ b/init/master-runcmd.cfg
@@ -5,6 +5,7 @@ runcmd:
   - yum clean metadata
   - yum install -y docker git java-1.8.0-amazon-corretto-devel python3-pip jq nfs-utils awslogs tree
   - mv /bin/pip /bin/pip2 && cp /bin/pip3 /bin/pip
+  - cp /etc/awslogs/awscli.conf.desired /etc/awslogs/awscli.conf
   - systemctl enable awslogsd
   - systemctl start awslogsd
   - groupadd -g 497 jenkins

--- a/init/master-write-files.cfg
+++ b/init/master-write-files.cfg
@@ -1,7 +1,7 @@
 #cloud-config
 
 write_files:
-  - path: /etc/awslogs/awscli.conf
+  - path: /etc/awslogs/awscli.conf.desired
     content: |
       [default]
       region = ${aws_region}


### PR DESCRIPTION
As write-files run before runcmd, the awscli.conf file was being overwritten by yum installs
This should create a temporary file and right before enabling awslogsd the file is copied over.
If this is not there, all logs will go to us-east-1 (default conf from the package)