### PR TITLE
Fix agent when docker image needs too much files or virtual memory

### DIFF
--- a/init/agent-runcmd.cfg
+++ b/init/agent-runcmd.cfg
@@ -5,9 +5,15 @@ runcmd:
   - yum clean metadata
   - yum install -y docker git java-1.8.0-amazon-corretto-devel python3-pip jq nfs-utils awslogs tree
   - mv /bin/pip /bin/pip2 && cp /bin/pip3 /bin/pip
+  # Fixes for java dependencies like elasticsearch which uses many files
+  - echo "vm.max_map_count=262144" | tee -a /etc/sysctl.conf
+  - echo "fs.file-max=65536" | tee -a /etc/sysctl.conf
+  - sysctl -p
+  - sed -i'' 's/1024:4096/65536:65536/' /etc/sysconfig/docker
+  - cp /etc/awslogs/awscli.conf.desired /etc/awslogs/awscli.conf
   - systemctl enable awslogsd
   - systemctl start awslogsd
-  - service docker start
+  - service docker restart
   - service docker enable
   - groupadd -g 497 jenkins
   - adduser -u 498 -g 497 -s /bin/bash -d /var/lib/jenkins -c "Jenkins Continuous Integration Server" jenkins


### PR DESCRIPTION
This helps when you are running tests and you need to run things like elastic search which requires
a lot of files and virtual memory