### PR TITLE
Tags cleanup

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,7 +1,7 @@
 # Local .terraform directories
-**/.terraform/*
+.terraform
 
-**/.vscode/*
+.vscode
 
 # .tfstate files
 *.tfstate
@@ -37,3 +37,4 @@ override.tf.json
 
 # Misc
 TODO
+.local

--- a/README.md
+++ b/README.md
@@ -213,15 +213,11 @@ EOF
 
 | Name | Description |
 |------|-------------|
-| agent_iam_role | The agent IAM role attributes. |
-| lb_arn_suffix | The ARN suffix of the load balancer. |
-| lb_dns_name | The DNS name of the load balancer. |
-| lb_id | The ID/ARN of the load balancer. |
-| lb_zone_id | The canonical hosted zone ID of the load balancer. |
-| master_iam_role | The master IAM role attributes |
-| r53_record_name | The name of the route 53 record. |
+| agent_asg_name | The name of the agent asg. Use for adding to addition outside resources. |
+| agent_iam_role | The agent IAM role attributes. Use for attaching additional iam policies. |
+| master_asg_name | The name of the master asg. Use for adding to addition outside resources. |
+| master_iam_role | The master IAM role name. Use for attaching additional iam policies. |
 | r53_record_fqdn | The fqdn of the route 53 record. |
-| r53_zone_id | The route 53 zone id. |
 
 ## Known Issues/Limitations
 

--- a/main.tf
+++ b/main.tf
@@ -64,19 +64,14 @@ data "aws_iam_policy" "amazon_ec2_role_for_ssm" {
 }
 
 resource "aws_lb" "lb" {
+  name                       = "${var.application}-lb"
   idle_timeout               = 60
   internal                   = false
-  name                       = "${var.application}-lb"
   security_groups            = [aws_security_group.lb_sg.id]
   subnets                    = data.aws_subnet_ids.public.ids
   enable_deletion_protection = false
 
-  tags = merge(
-    var.tags,
-    {
-      "Name" = "${var.application}-lb"
-    },
-  )
+  tags = merge(var.tags, { Name = "${var.application}-lb" })
 }
 
 resource "aws_security_group" "lb_sg" {
@@ -105,12 +100,7 @@ resource "aws_security_group" "lb_sg" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags = merge(
-    var.tags,
-    {
-      "Name" = "${var.application}-lb-sg"
-    },
-  )
+  tags = merge(var.tags, { Name = "${var.application}-lb-sg" })
 }
 
 resource "aws_route53_record" "r53_record" {
@@ -257,12 +247,7 @@ resource "aws_security_group" "agent_sg" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags = merge(
-    var.tags,
-    {
-      "Name" = "${var.application}-agent-sg"
-    },
-  )
+  tags = merge(var.tags, { Name = "${var.application}-agent-sg" })
 }
 
 resource "aws_iam_instance_profile" "agent_ip" {
@@ -290,13 +275,7 @@ resource "aws_iam_role" "agent_iam_role" {
 }
 EOF
 
-
-  tags = merge(
-    var.tags,
-    {
-      "Name" = "${var.application}-agent-iam-role"
-    },
-  )
+  tags = merge(var.tags, { Name = "${var.application}-agent-iam-role" })
 }
 
 resource "aws_iam_role_policy" "agent_inline_policy" {
@@ -354,7 +333,6 @@ resource "aws_iam_role_policy" "agent_inline_policy" {
   ]
 }
 EOF
-
 }
 
 resource "aws_iam_role_policy_attachment" "agent_policy_attachment" {
@@ -364,13 +342,7 @@ resource "aws_iam_role_policy_attachment" "agent_policy_attachment" {
 
 resource "aws_cloudwatch_log_group" "agent_logs" {
   name = "${var.application}-agent-logs"
-
-  tags = merge(
-    var.tags,
-    {
-      "Name" = "${var.application}-agent-logs"
-    },
-  )
+  tags = merge(var.tags, { Name = "${var.application}-agent-logs" })
 }
 
 data "template_cloudinit_config" "agent_init" {
@@ -536,12 +508,7 @@ resource "aws_security_group" "master_sg" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags = merge(
-    var.tags,
-    {
-      "Name" = "${var.application}-master-sg"
-    },
-  )
+  tags = merge(var.tags, { Name = "${var.application}-master-sg" })
 }
 
 resource "aws_iam_instance_profile" "master_ip" {
@@ -569,13 +536,7 @@ resource "aws_iam_role" "master_iam_role" {
 }
 EOF
 
-
-  tags = merge(
-    var.tags,
-    {
-      "Name" = "${var.application}-master-iam-role"
-    },
-  )
+  tags = merge(var.tags, { Name = "${var.application}-master-iam-role" })
 }
 
 resource "aws_iam_role_policy" "master_inline_policy" {
@@ -628,7 +589,6 @@ resource "aws_iam_role_policy" "master_inline_policy" {
   ]
 }
 EOF
-
 }
 
 resource "aws_iam_role_policy_attachment" "master_policy_attachment" {
@@ -638,13 +598,7 @@ resource "aws_iam_role_policy_attachment" "master_policy_attachment" {
 
 resource "aws_cloudwatch_log_group" "master_logs" {
   name = "${var.application}-master-logs"
-
-  tags = merge(
-    var.tags,
-    {
-      "Name" = "${var.application}-master-logs"
-    },
-  )
+  tags = merge(var.tags, { Name = "${var.application}-master-logs" })
 }
 
 data "template_cloudinit_config" "master_init" {
@@ -718,12 +672,7 @@ resource "aws_efs_file_system" "master_efs" {
   throughput_mode                 = var.efs_mode
   provisioned_throughput_in_mibps = var.efs_mode == "provisioned" ? var.efs_provisioned_throughput : null
 
-  tags = merge(
-    var.tags,
-    {
-      "Name" = "${var.application}-master-efs"
-    },
-  )
+  tags = merge(var.tags, { Name = "${var.application}-master-efs" })
 }
 
 resource "aws_efs_mount_target" "mount_targets" {
@@ -754,12 +703,7 @@ resource "aws_security_group" "master_storage_sg" {
     cidr_blocks = ["0.0.0.0/0"]
   }
 
-  tags = merge(
-    var.tags,
-    {
-      "Name" = "${var.application}-master-storage-sg"
-    },
-  )
+  tags = merge(var.tags, { Name = "${var.application}-master-storage-sg" })
 }
 
 resource "aws_lb_target_group" "master_tg" {
@@ -779,12 +723,7 @@ resource "aws_lb_target_group" "master_tg" {
     matcher             = "200-299"
   }
 
-  tags = merge(
-    var.tags,
-    {
-      "Name" = "${var.application}-master-tg"
-    },
-  )
+  tags = merge(var.tags, { Name = "${var.application}-master-tg" })
 }
 
 resource "aws_lb_listener" "master_lb_listener" {

--- a/outputs.tf
+++ b/outputs.tf
@@ -1,44 +1,24 @@
+output "agent_asg_name" {
+  description = "The name of the agent asg. Use for adding to addition outside resources."
+  value       = aws_autoscaling_group.agent_asg.name
+}
+
 output "agent_iam_role" {
-  value       = aws_iam_role.agent_iam_role
-  description = "The agent IAM role attributes."
+  description = "The agent IAM role attributes. Use for attaching additional iam policies."
+  value       = aws_iam_role.agent_iam_role.name
 }
 
-output "lb_arn_suffix" {
-  value       = aws_lb.lb.arn_suffix
-  description = "The ARN suffix of the load balancer."
-}
-
-output "lb_dns_name" {
-  value       = aws_lb.lb.dns_name
-  description = "The DNS name of the load balancer."
-}
-
-output "lb_id" {
-  value       = aws_lb.lb.id
-  description = "The ID/ARN of the load balancer."
-}
-
-output "lb_zone_id" {
-  value       = aws_lb.lb.zone_id
-  description = "The canonical hosted zone ID of the load balancer."
+output "master_asg_name" {
+  description = "The name of the master asg. Use for adding to addition outside resources."
+  value       = aws_autoscaling_group.master_asg.name
 }
 
 output "master_iam_role" {
-  value       = aws_iam_role.master_iam_role
-  description = "The master IAM role attributes."
-}
-
-output "r53_record_name" {
-  value       = aws_route53_record.r53_record.name
-  description = "The name of the route 53 record."
+  description = "The master IAM role name. Use for attaching additional iam policies."
+  value       = aws_iam_role.master_iam_role.name
 }
 
 output "r53_record_fqdn" {
-  value       = aws_route53_record.r53_record.fqdn
   description = "The fqdn of the route 53 record."
-}
-
-output "r53_zone_id" {
-  value       = data.aws_route53_zone.r53_zone.zone_id
-  description = "The route 53 zone id."
+  value       = aws_route53_record.r53_record.fqdn
 }


### PR DESCRIPTION
Cleanup outputs to be useful. The ASG outputs allow for additional alarms outside of the module. The IAM outputs allow for additional policy attachments outside of the module. Will be released with v2.5.0

Cleanup tags to look a little better.