### PR TITLE
Update examples to work w/ registry. Update badges

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 # terraform-aws-jenkins-ha-agents
 
-![version](https://img.shields.io/badge/version-v2.5.4-green.svg?style=flat) ![license](https://img.shields.io/badge/license-Apache%202.0-blue.svg?style=flat)
+[![verson](https://img.shields.io/github/v/release/neiman-marcus/terraform-aws-jenkins-ha-agents)](https://registry.terraform.io/modules/neiman-marcus/jenkins-ha-agents/aws) [![build](https://img.shields.io/github/workflow/status/neiman-marcus/terraform-aws-jenkins-ha-agents/tf-lint)](https://github.com/neiman-marcus/terraform-aws-jenkins-ha-agents/actions?query=workflow%3Atf-lint) [![license](https://img.shields.io/badge/license-Apache%202.0-blue.svg)](https://github.com/neiman-marcus/terraform-aws-jenkins-ha-agents/blob/master/LICENSE) [![pr](https://img.shields.io/badge/PRs-welcome-blue.svg)](https://github.com/neiman-marcus/terraform-aws-jenkins-ha-agents/blob/master/CONTRIBUTING.md)
 
 A module for deploying Jenkins in a highly available and highly scalable manner.
 

--- a/examples/full/main.tf
+++ b/examples/full/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 module "jenkins_ha_agents" {
-  source  = "neiman-marcus/jenkins-ha-agents/aws"
+  source  = "../../"
 
   admin_password    = var.admin_password
   agent_max         = var.agent_max

--- a/examples/minimum/main.tf
+++ b/examples/minimum/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 module "jenkins_ha_agents" {
-  source  = "neiman-marcus/jenkins-ha-agents/aws"
+  source  = "../../"
 
   admin_password  = var.admin_password
   bastion_sg_name = var.bastion_sg_name


### PR DESCRIPTION
@kevin-dsouza, FYI future releases need to be done in the github console for the new release version badge to work properly, not simply git tag.

Badges are now dynamic and do not require manual updating.

Examples now will work directly through the tf registry.