### PR TITLE
Include LB outputs.

### DIFF
--- a/examples/full/main.tf
+++ b/examples/full/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 module "jenkins_ha_agents" {
-  source  = "../../"
+  source = "../../"
 
   admin_password    = var.admin_password
   agent_max         = var.agent_max

--- a/examples/minimum/main.tf
+++ b/examples/minimum/main.tf
@@ -19,7 +19,7 @@ locals {
 }
 
 module "jenkins_ha_agents" {
-  source  = "../../"
+  source = "../../"
 
   admin_password  = var.admin_password
   bastion_sg_name = var.bastion_sg_name

--- a/outputs.tf
+++ b/outputs.tf
@@ -8,6 +8,16 @@ output "agent_iam_role" {
   value       = aws_iam_role.agent_iam_role.name
 }
 
+output "lb_dns_name" {
+  value       = aws_lb.lb.dns_name
+  description = "The DNS name of the load balancer."
+}
+
+output "lb_zone_id" {
+  value       = aws_lb.lb.zone_id
+  description = "The canonical hosted zone ID of the load balancer."
+}
+
 output "master_asg" {
   description = "The name of the master asg. Use for adding to addition outside resources."
   value       = aws_autoscaling_group.master_asg.name


### PR DESCRIPTION
Adding dns lb outputs for adding more route53 entries outside the module.