### PR TITLE
Fix awslogs permissions to PutLogEvents

### DIFF
--- a/main.tf
+++ b/main.tf
@@ -356,7 +356,7 @@ resource "aws_iam_role_policy" "agent_inline_policy" {
         "logs:DescribeLogStreams"
       ],
       "Effect": "Allow",
-      "Resource": "${aws_cloudwatch_log_group.agent_logs.arn}"
+      "Resource": "${aws_cloudwatch_log_group.agent_logs.arn}:*"
     },
     {
       "Action": [
@@ -661,7 +661,7 @@ resource "aws_iam_role_policy" "master_inline_policy" {
         "logs:DescribeLogStreams"
       ],
       "Effect": "Allow",
-      "Resource": "${aws_cloudwatch_log_group.master_logs.arn}"
+      "Resource": "${aws_cloudwatch_log_group.master_logs.arn}:*"
     },
     {
       "Action": [


### PR DESCRIPTION
Hey there, I was trying to check some jenkins logs and saw that since last year they all stopped being sent to cloudwatch and when I checked awslogs.log I saw many of the following errors:
```
2021-02-15 15:15:45,249 - cwlogs.threads - ERROR - 2805 - Thread-1813 - Exception caught in <EventBatchPublisher(Thread-1813, started daemon 139710578026240)>
Traceback (most recent call last):
  File "/usr/lib/python2.7/site-packages/cwlogs/threads.py", line 58, in run
    self._run()
  File "/usr/lib/python2.7/site-packages/cwlogs/push.py", line 1403, in _run
    self._publish_event_batch()
  File "/usr/lib/python2.7/site-packages/cwlogs/push.py", line 1210, in _publish_event_batch
    self.sequence_token = self._put_log_events(self.event_batch)
  File "/usr/lib/python2.7/site-packages/cwlogs/push.py", line 1248, in _put_log_events
    response = self.logs_service.put_log_events(**params)
  File "/usr/lib/python2.7/site-packages/botocore/client.py", line 337, in _api_call
    return self._make_api_call(operation_name, kwargs)
  File "/usr/lib/python2.7/site-packages/botocore/client.py", line 656, in _make_api_call
    raise error_class(parsed_response, operation_name)
ClientError: An error occurred (AccessDeniedException) when calling the PutLogEvents operation: User: arn:aws:sts::xxxx:assumed-role/jenkins-master-iam-role/i-xxxxxxxxx is not authorized to perform: logs:PutLogEvents on resource: arn:aws:logs:region:xxxxxx:log-group:jenkins-master-logs:log-stream:i-xxxxxxxxxxxx/var/log/jenkins/jenkins.log
2021-02-15 15:15:48,224 - cwlogs.push.stream - WARNING - 2805 - Thread-1 - No file is found with given path '/var/log/amazon/ssm/errors.log'.
2021-02-15 15:15:48,224 - cwlogs.push.stream - WARNING - 2805 - Thread-1 - No file is found with given path '/var/log/amazon/efs/mount.log'
```
I don't know if  AWS changed something on how the IAM for PutLogEvents changed but this was all over the place.
With the current change, I can see the logs coming back again.
