### PR TITLE
CLOUDCOE-4135: Create `/tmp/tools` on Jenkins agents with correct permissions

### DIFF
--- a/init/agent-runcmd.cfg
+++ b/init/agent-runcmd.cfg
@@ -12,8 +12,8 @@ runcmd:
   - service docker enable
   - groupadd -g 497 jenkins
   - adduser -u 498 -g 497 -s /bin/bash -d /var/lib/jenkins -c "Jenkins Continuous Integration Server" jenkins
-  - mkdir -p /var/lib/jenkins
-  - chown -R jenkins:jenkins /var/lib/jenkins
+  - mkdir -pv /var/lib/jenkins /tmp/tools
+  - chown -R jenkins:jenkins /var/lib/jenkins /tmp/tools
   - cd /var/lib/jenkins
   - curl https://repo.jenkins-ci.org/releases/org/jenkins-ci/plugins/swarm-client/${swarm_version}/swarm-client-${swarm_version}.jar --output swarm-client-${swarm_version}.jar
   - usermod -a -G docker jenkins

--- a/main.tf
+++ b/main.tf
@@ -64,8 +64,8 @@ data "aws_subnet_ids" "public" {
 }
 
 data "aws_acm_certificate" "certificate" {
-  domain   = var.ssl_certificate
-  statuses = ["ISSUED"]
+  domain      = var.ssl_certificate
+  statuses    = ["ISSUED"]
   most_recent = true
 }
 


### PR DESCRIPTION
Create `/tmp/tools` on Jenkins agents with correct permissions `jenkins:jenkins`, to avoid `root:root` owner.