### PR TITLE
CLOUDCOE-5052: split instance_type

### DIFF
--- a/README.md
+++ b/README.md
@@ -97,10 +97,11 @@ module "jenkins_ha_agents" {
 
   retention_in_days = 90
 
-  executors              = 4
-  instance_type          = ["t3a.xlarge", "t3.xlarge", "t2.xlarge"]
-  jenkins_version        = "2.249.1"
-  password_ssm_parameter = "/admin_password"
+  executors                = 4
+  instance_type_controller = ["t3a.2xlarge"]
+  instance_type_agents     = ["t3a.xlarge", "t3.xlarge", "t2.xlarge"]
+  jenkins_version          = "2.249.1"
+  password_ssm_parameter   = "/admin_password"
 
   cidr_ingress        = ["0.0.0.0/0"]
   private_subnet_name = "private-subnet-*"
@@ -198,7 +199,8 @@ runcmd:
 | extra_agent_userdata_merge  | Control how cloud-init merges custom agent user-data sections.                                                                                                             | string | `list(append) + dict(recurse_array) + str()` |    no    |
 | extra_master_userdata       | Extra master user-data to add to the default built-in. Created from a template outside of the module.                                                                      | string |                   `empty`                    |    no    |
 | extra_master_userdata_merge | Control how cloud-init merges custom master user-data sections.                                                                                                            | string | `list(append) + dict(recurse_array) + str()` |    no    |
-| instance_type               | The type of instances to use for both ASG's. The first value in the list will be set as the master instance.                                                               |  list  |      `t3a.xlarge, t3.xlarge, t2.xlarge`      |    no    |
+| instance_type_controller    | The type of instances to use for controller autoscaling group (ASG)                                                                                                        |  list  |`t3a.xlarge`                                  |    no    |
+| instance_type_agents        | The type of instances to use for agent's autoscaling group (ASG)"                                                                                                          |  list  |`t3.xlarge, t3a.xlarge, t2.xlarge, t2a.xlarge`|    no    |
 | jenkins_version             | The version number of Jenkins to use on the master. Change this value when a new version comes out, and it will update the launch configuration and the autoscaling group. | string |                  `2.249.1`                   |    no    |
 | key_name                    | SSH Key to launch instances.                                                                                                                                               | string |                    `null`                    |    no    |
 | master_lt_version           | The version of the master launch template to use. Only use if you need to programatically select an older version of the launch template. Not recommended to change.       | string |                  `$Latest`                   |    no    |

--- a/examples/full/main.tf
+++ b/examples/full/main.tf
@@ -60,7 +60,6 @@ module "jenkins_ha_agents" {
   retention_in_days = var.retention_in_days
 
   executors                = var.executors
-  instance_type            = var.instance_type
   instance_type_controller = var.instance_type_controller
   instance_type_agents     = var.instance_type_agents
   password_ssm_parameter   = var.password_ssm_parameter

--- a/examples/full/main.tf
+++ b/examples/full/main.tf
@@ -59,10 +59,11 @@ module "jenkins_ha_agents" {
 
   retention_in_days = var.retention_in_days
 
-  executors              = var.executors
-  instance_type          = var.instance_type
-  jenkins_version        = var.jenkins_version
-  password_ssm_parameter = var.password_ssm_parameter
+  executors                = var.executors
+  instance_type            = var.instance_type
+  instance_type_controller = var.instance_type_controller
+  instance_type_agents     = var.instance_type_agents
+  password_ssm_parameter   = var.password_ssm_parameter
 
   cidr_ingress        = var.cidr_ingress
   private_subnet_name = var.private_subnet_name

--- a/examples/full/terraform.tfvars
+++ b/examples/full/terraform.tfvars
@@ -32,7 +32,8 @@ environment = "prod"
 
 executors = 4
 
-instance_type = ["t3a.xlarge", "t3.xlarge", "t2.xlarge"]
+instance_type_controller = ["t3.2xlarge"]
+instance_type_agents     = ["t3.xlarge", "t3a.xlarge", "t2.xlarge"]
 
 jenkins_version = "2.249.1"
 

--- a/examples/full/variables.tf
+++ b/examples/full/variables.tf
@@ -103,10 +103,16 @@ variable "executors" {
   default     = 4
 }
 
-variable "instance_type" {
-  description = "The type of instances to use for both ASG's. The first value in the list will be set as the master instance."
+variable "instance_type_controller" {
+  description = "The type of instances to use for controller autoscaling group (ASG)."
   type        = list(string)
-  default     = ["t3a.xlarge", "t3.xlarge", "t2.xlarge"]
+  default     = ["t3a.xlarge"]
+}
+
+variable "instance_type_agents" {
+  description = "The type of instances to use for agent's autoscaling group (ASG)"
+  type        = list(string)
+  default     = ["t3.xlarge", "t3a.xlarge", "t2.xlarge", "t2a.xlarge"]
 }
 
 variable "jenkins_version" {

--- a/main.tf
+++ b/main.tf
@@ -217,7 +217,7 @@ resource "aws_autoscaling_group" "agent_asg" {
         version            = var.agent_lt_version
       }
 
-      # Why???
+      # The mixed instance policy allows multiple override instance types
       dynamic "override" {
         for_each = var.instance_type_agents
         content {

--- a/main.tf
+++ b/main.tf
@@ -217,6 +217,7 @@ resource "aws_autoscaling_group" "agent_asg" {
         version            = var.agent_lt_version
       }
 
+      # Why???
       dynamic "override" {
         for_each = var.instance_type
         content {
@@ -265,7 +266,7 @@ resource "aws_launch_template" "agent_lt" {
   key_name      = var.key_name
   ebs_optimized = false
 
-  instance_type = var.instance_type[0]
+  instance_type = var.instance_type_agents[0]
   user_data     = data.template_cloudinit_config.agent_init.rendered
 
   monitoring {
@@ -494,7 +495,7 @@ resource "aws_autoscaling_group" "master_asg" {
       }
 
       override {
-        instance_type = var.instance_type[0]
+        instance_type = var.instance_type_controller[0]
       }
 
     }
@@ -538,7 +539,7 @@ resource "aws_launch_template" "master_lt" {
   key_name      = var.key_name
   ebs_optimized = false
 
-  instance_type = var.instance_type[0]
+  instance_type = var.instance_type_controller[0]
   user_data     = data.template_cloudinit_config.master_init.rendered
 
   monitoring {

--- a/main.tf
+++ b/main.tf
@@ -208,7 +208,7 @@ resource "aws_autoscaling_group" "agent_asg" {
     instances_distribution {
       on_demand_base_capacity                  = 0
       on_demand_percentage_above_base_capacity = 0
-      spot_instance_pools                      = length(var.instance_type)
+      spot_instance_pools                      = length(var.instance_type_agents)
     }
 
     launch_template {
@@ -219,7 +219,7 @@ resource "aws_autoscaling_group" "agent_asg" {
 
       # Why???
       dynamic "override" {
-        for_each = var.instance_type
+        for_each = var.instance_type_agents
         content {
           instance_type = override.value
         }

--- a/variables.tf
+++ b/variables.tf
@@ -122,13 +122,13 @@ variable "extra_master_userdata_merge" {
 }
 
 variable "instance_type_controller" {
-  description = "The type of instances to use for both ASG's. The first value in the list will be set as the master instance."
+  description = "The type of instances to use for controller autoscaling group (ASG)."
   type        = list(string)
   default     = ["t3a.xlarge"]
 }
 
 variable "instance_type_agents" {
-  description = "The type of instances to use for both ASG's. The first value in the list will be set as the master instance."
+  description = "The type of instances to use for agent's autoscaling group (ASG)"
   type        = list(string)
   default     = ["t3.xlarge", "t3a.xlarge", "t2.xlarge", "t2a.xlarge"]
 }

--- a/variables.tf
+++ b/variables.tf
@@ -121,10 +121,16 @@ variable "extra_master_userdata_merge" {
   default     = "list(append)+dict(recurse_array)+str()"
 }
 
-variable "instance_type" {
+variable "instance_type_controller" {
   description = "The type of instances to use for both ASG's. The first value in the list will be set as the master instance."
   type        = list(string)
-  default     = ["t3a.xlarge", "t3.xlarge", "t2.xlarge"]
+  default     = ["t3a.xlarge"]
+}
+
+variable "instance_type_agents" {
+  description = "The type of instances to use for both ASG's. The first value in the list will be set as the master instance."
+  type        = list(string)
+  default     = ["t3.xlarge", "t3a.xlarge", "t2.xlarge", "t2a.xlarge"]
 }
 
 variable "jenkins_version" {


### PR DESCRIPTION
Split `instance_type` to:
* `instance_type_controller`
* `instance_type_agents`

to avoid creating of autoscaling group with wrong instance type.

This code is not compatible with previous versions. It is better to change the major version.