### PR TITLE
Fix launch time at small instances

### DIFF
--- a/examples/full/main.tf
+++ b/examples/full/main.tf
@@ -43,6 +43,8 @@ module "jenkins_ha_agents" {
   scale_down_number = var.scale_down_number
   scale_up_number   = var.scale_up_number
 
+  time_to_start = var.time_to_start
+
   auto_update_plugins_cron = var.auto_update_plugins_cron
 
   custom_plugins = templatefile("init/custom_plugins.cfg", {})

--- a/examples/full/variables.tf
+++ b/examples/full/variables.tf
@@ -198,3 +198,8 @@ variable "vpc_name" {
   type        = string
 }
 
+variable "time_to_start" {
+  description = "Set a timeout in seconds when systemctl will restart service due of inactivity, if instance became smaller than timeout has to be bigger. Default 90 seconds."
+  type        = string
+  default     = 90
+}

--- a/init/master-runcmd.cfg
+++ b/init/master-runcmd.cfg
@@ -13,6 +13,8 @@ runcmd:
   - adduser -u 498 -g 497 -s /bin/bash -d /var/lib/jenkins -c "Jenkins Continuous Integration Server" jenkins
   - mkdir -pv /var/lib/jenkins
   - chown -R jenkins:jenkins /var/lib/jenkins
+  - sudo mkdir /etc/systemd/system/jenkins.service.d
+  - echo -e "[Service]\nTimeoutStartSec=${time_to_start}" | sudo tee /etc/systemd/system/jenkins.service.d/startup-timeout.conf
   - while ! (echo > /dev/tcp/${master_storage}.efs.${aws_region}.amazonaws.com/2049) >/dev/null 2>&1; do sleep 10; done && sleep 10 && mount -t nfs4 -o nfsvers=4.1,rsize=1048576,wsize=1048576,hard,timeo=600,retrans=2 "${master_storage}.efs.${aws_region}.amazonaws.com:/" /var/lib/jenkins
   - yum install -y https://pkg.jenkins.io/redhat-stable/jenkins-${jenkins_version}-1.1.noarch.rpm
   - service jenkins start

--- a/main.tf
+++ b/main.tf
@@ -725,6 +725,7 @@ data "template_cloudinit_config" "master_init" {
         aws_region      = var.region,
         jenkins_version = var.jenkins_version,
         master_storage  = aws_efs_file_system.master_efs.id
+        time_to_start   = var.time_to_start
       }
     )
   }


### PR DESCRIPTION
If select a smaller instance than `t3.xlarge` than jenkins does not have enough time to startup before `systemctl` will try to restart `jenkins.service`

This pull request add additional variable to have control under the timeout before `systemctl` will restart jenkins with resolution 
`systemd: jenkins.service start operation timed out. Terminating.`

How to reproduce issue:
- Set instance type for master as `t3.small`

How to test:
- Checkout to this PR
- Set variable `time_to_start = 900 #15 mins`

Example

```terraform
provider "aws" {
  region  = var.region
  profile = var.profile
  default_tags {
    tags = {
      Environment = var.environment
      Owner       = "terraform"
      Project     = var.profile
      terraform   = "true"
    }
  }
}

data "terraform_remote_state" "remote" {
  backend = "s3"

  config = {
    profile = var.profile
    region  = var.region
    bucket  = "terraform-state"
    key     = "developemnt/terraform.tfstate"
  }
}

data "terraform_remote_state" "route53" {
  backend = "s3"

  config = {
    profile = var.profile
    region  = var.region
    bucket  = "terraform-state"
    key     = "global/route53/terraform.tfstate"
  }
}

locals {
  tags = {
    # contact     = var.contact
    # environment = var.environment
  }
}

module "jenkins_ha_agents" {
  # source          = "neiman-marcus/jenkins-ha-agents/aws"
  source          = "github.com/ValeriyDP/terraform-aws-jenkins-ha-agents"

  admin_password           = var.admin_password == "" ? random_password.admin_password[0].result : var.admin_password
  agent_max                = var.agent_max
  agent_min                = var.agent_min
  agent_volume_size        = var.agent_volume_size
  scale_down_number        = -1
  scale_up_number          = 1
  key_name                 = data.terraform_remote_state.remote.outputs.key_pair_name
  instance_type_controller = ["t3a.small"]
  instance_type_agents     = ["t3.xlarge", "t3a.xlarge"]

  time_to_start = 60 * 60

  custom_plugins = templatefile("init/custom_plugins.cfg", {})

  bastion_sg_name = data.terraform_remote_state.remote.outputs.bastion_sg[0].name
  domain_name     = "${data.terraform_remote_state.route53.outputs.dns_zone_prefix}."

  private_subnet_name = "${var.environment}-${var.project_name}-private-*"
  public_subnet_name  = "${var.environment}-${var.project_name}-public-*"

  r53_record = "ci.${data.terraform_remote_state.route53.outputs.dns_zone_prefix}"
  region     = var.region

  ssl_certificate = data.terraform_remote_state.route53.outputs.dns_zone_prefix
  ssm_parameter   = "/dev/ci/jenkins"

  tags     = local.tags
  vpc_name = "${var.environment}-${var.project_name}"
}

resource "random_password" "admin_password" {
  count       = var.admin_password == "" ? 1 : 0
  length      = 12
  special     = false
  lower       = true
  numeric     = true
  min_numeric = 4
  min_lower   = 4
  min_special = 0
  min_upper   = 4
}

```

Links for reference:
- https://community.jenkins.io/t/job-for-jenkins-service-failed-because-a-timeout-was-exceeded/2443
- https://askubuntu.com/questions/1444777/installing-jenkins-service-fails-with-result-timeout