### PR TITLE
use latest version of docker

### DIFF
--- a/init/agent-runcmd.cfg
+++ b/init/agent-runcmd.cfg
@@ -1,7 +1,7 @@
 #cloud-config
 
 runcmd:
-  - amazon-linux-extras enable corretto8 docker=18.06.1
+  - amazon-linux-extras enable corretto8 docker
   - yum clean metadata
   - yum install -y docker git java-1.8.0-amazon-corretto-devel python3-pip jq nfs-utils awslogs tree
   - mv /bin/pip /bin/pip2 && cp /bin/pip3 /bin/pip

--- a/init/master-runcmd.cfg
+++ b/init/master-runcmd.cfg
@@ -1,7 +1,7 @@
 #cloud-config
 
 runcmd:
-  - amazon-linux-extras enable docker=18.06.1
+  - amazon-linux-extras enable docker
   - yum clean metadata
   - yum install -y docker git java-11-amazon-corretto.x86_64 python3-pip jq nfs-utils awslogs tree
   - mv /bin/pip /bin/pip2 && cp /bin/pip3 /bin/pip


### PR DESCRIPTION
Master and agent to install the latest version of docker on init.

Fixes "The JAVA_HOME environment variable is not defined correctly" when using latest maven docker image to build.
[docker-maven/issues/282](https://github.com/carlossg/docker-maven/issues/282#issuecomment-1142248971)